### PR TITLE
refactor: Create LayoutModule for better modularity

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,23 +4,19 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { FooterComponent } from './layout/footer/footer.component';
-import { HeaderComponent } from './layout/header/header.component';
-import { SidebarComponent } from './layout/sidebar/sidebar.component';
 import { SharedModule } from './shared/shared.module';
+import { LayoutModuleModule } from './layout/layout-module.module';
 
 @NgModule({
   declarations: [
     AppComponent,
-    HeaderComponent,
-    FooterComponent,
-    SidebarComponent,
   ],
   imports: [
     BrowserModule,
     AppRoutingModule,
     BrowserAnimationsModule,
-    SharedModule
+    SharedModule,
+    LayoutModuleModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/layout/layout-module.module.ts
+++ b/src/app/layout/layout-module.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HeaderComponent } from './header/header.component';
+import { FooterComponent } from './footer/footer.component';
+import { SidebarComponent } from './sidebar/sidebar.component';
+
+@NgModule({
+  declarations: [
+    HeaderComponent,
+    FooterComponent,
+    SidebarComponent
+  ],
+  imports: [
+    CommonModule
+  ],
+  exports: [
+    HeaderComponent,
+    FooterComponent,
+    SidebarComponent
+  ]
+})
+export class LayoutModuleModule { }


### PR DESCRIPTION
moved `HeaderComponent`, `FooterComponent`, and `SidebarComponent` from `AppModule `to a new `LayoutModule`.

This change improves the modularity of the application by encapsulating the layout-related components into their own module. `AppModule` now imports `LayoutModule` to make these components available.